### PR TITLE
fix: 优化翻译文件检测逻辑

### DIFF
--- a/check-ts-files.ts
+++ b/check-ts-files.ts
@@ -189,13 +189,18 @@ function findTsFiles(dir: string): string[] {
  * - project_zh_CN.ts
  * - translation_zh_CN.ts
  * - 任何前缀_zh_CN.ts
+ * - 任何前缀_ast.ts（三字母语言代码）
+ * - 任何前缀_af_ZA.ts（带地区的语言代码）
  * 
  * @param filename 文件名
  * @returns 语言代码或null（如果不匹配）
  */
 function extractLanguageCode(filename: string): string | null {
-    // 使用更通用的正则表达式匹配任何前缀后跟下划线和语言代码的模式
-    const match = filename.match(/.*_([a-z]{2}(?:_[A-Z]{2})?)\.ts$/);
+    // 使用更宽松的正则表达式，支持：
+    // 1. 2-3个字母的语言代码
+    // 2. 带地区的语言代码（如af_ZA）
+    // 3. 支持任意前缀
+    const match = filename.match(/.*_([a-z]{2,3}(?:_[A-Z]{2,3})?)\.ts$/);
     if (!match) return null;
     return match[1];
 }
@@ -324,7 +329,9 @@ export async function processAllTsFiles() {
                 }
                 
                 if (!languageCodes.includes(langCode)) {
-                    console.log(`  跳过文件 ${file} - 语言代码 ${langCode} 不在language.yml中`);
+                    console.log(`  注意：文件 ${file} - 语言代码 ${langCode} 不在language.yml中，但作为tx pull获取的新语种将被处理`);
+                    // 仍然添加到匹配文件中进行处理
+                    matchingTsFiles.push({ file, langCode });
                     continue;
                 }
                 


### PR DESCRIPTION
1. 修改语言代码提取正则表达式，支持：
   - 三字母语言代码(如ast)
   - 带地区的语言代码(如af_ZA)
2. 调整新语种处理逻辑，将tx pull获取的新语种文件标记为待处理
3. 改进日志输出，更清晰地显示新语种的处理状态

这些修改解决了以下问题：
- 之前无法识别三字母语言代码(如ast)的问题
- 新语种文件被错误跳过的问题
- 确保支持所有标准语言代码格式

## Summary by Sourcery

Optimize translation file detection to support three-letter and region-specific language codes, ensure new language files from tx pull are marked for processing, and clarify logs on new language status

Bug Fixes:
- Fix failure to recognize three-letter language codes (e.g., ast)
- Fix skipping of new language files not listed in language.yml

Enhancements:
- Expand regex to match 2–3 letter codes with optional region suffix
- Log and retain new language files pulled by tx for subsequent processing